### PR TITLE
Made an lalt key. And default ralt

### DIFF
--- a/Actions/KeyDownUpBaseAction.m
+++ b/Actions/KeyDownUpBaseAction.m
@@ -36,7 +36,8 @@
     return [NSDictionary dictionaryWithObjectsAndKeys:
             @"59", @"ctrl",
             @"55", @"cmd",
-            @"58", @"alt",
+            @"58", @"lalt",
+            @"61", @"alt",
             @"56", @"shift",
             @"63", @"fn",
             nil];


### PR DESCRIPTION
This changes the default alt-modifier key to be the right alt-key, instead of the left alt-key. This allows cliclick to type special character like `®¥πß©∞`, into at Linux Virtual Machine. 

A left alt-key is also added, so that people who specifically needs the left alt-key, are able to do so. 
Just use the `lalt` option, instead of `alt`. 